### PR TITLE
Fix tradegoods parameter

### DIFF
--- a/ikabot/function/modifyProduction.py
+++ b/ikabot/function/modifyProduction.py
@@ -107,11 +107,12 @@ def modifyProduction(session, event, stdin_fd, predetermined_input):
                         finalWorkers = int(max_normal / 100 * percentageWorkers)
                     
                     # Set the workers
+                    worker_key = "rw" if resource_type == "resource" else "tw"    
                     session.post(params={
                         "islandId": islandId, "cityId": city["id"],
                         "type": resource_type, "screen": resource_type,
                         "action": "IslandScreen", "function": "workerPlan",
-                        "rw": finalWorkers, "templateView": resource_type,
+                         worker_key: finalWorkers, "templateView": resource_type,
                         "actionRequest": actionRequest, "ajax": "1"
                     })
                     


### PR DESCRIPTION
Fixed tradegoods parameter (tw) on modifyProduction.py function.

Previously, option 2 (tradegood) didn't work because it sent the rw parameter incorrectly. For goods, the correct parameter is tw.