### PR TITLE
Fix TypeError: unsupported operand type(s) for -: 'str' and 'int' in …

### DIFF
--- a/ikabot/function/activateMiracle.py
+++ b/ikabot/function/activateMiracle.py
@@ -91,7 +91,7 @@ def obtainMiraclesAvailable(session):
                 island["wonderActivationLevel"] = level
                 island["available"] = available
                 if available is False:
-                    island["available_in"] = enddate - currentdate
+                    island["available_in"] = int(float(enddate)) - int(float(currentdate))
                 break
 
     # only return island which wonder we can activate
@@ -209,7 +209,7 @@ def activateMiracle(session, event, stdin_fd, predetermined_input):
                     enddate = data[elem]["countdown"]["enddate"]
                     currentdate = data[elem]["countdown"]["currentdate"]
                     break
-            wait_time = enddate - currentdate
+            wait_time = int(float(enddate)) - int(float(currentdate))
 
             print("The miracle {} was activated.".format(island["wonderName"]))
             enter()


### PR DESCRIPTION
…activateMiracle.py

Sometimes the enddate is a string. This fixes this for all cases where enddate and current date both only contain numbers or decimal points.

Error I want to fix with this:

```
Error in:
I activate the miracle Hephaestus’ Forge 7777777777777 times

Cause:
Traceback (most recent call last):
  File "/usr/lib/python3.12/site-packages/ikabot/function/activateMiracle.py", line 304, in activateMiracle
    do_it(session, island, iterations)
  File "/usr/lib/python3.12/site-packages/ikabot/function/activateMiracle.py", line 371, in do_it
    wait_for_miracle(session, island)
  File "/usr/lib/python3.12/site-packages/ikabot/function/activateMiracle.py", line 337, in wait_for_miracle
    wait_time = enddate - currentdate
                ~~~~~~~~^~~~~~~~~~~~~
TypeError: unsupported operand type(s) for -: 'str' and 'int'
```