### PR TITLE
fix: integer conversion in buyResources

### DIFF
--- a/ikabot/function/buyResources.py
+++ b/ikabot/function/buyResources.py
@@ -90,7 +90,7 @@ def getOffers(session, city):
             "jugadorAComprar": hit[1],
             "bienesXminuto": int(hit[2]),
             "amountAvailable": int(
-                hit[3].replace(",", "").replace(".", "").replace("<", "").replace(" ", "")
+                hit[3].replace(",", "").replace(".", "").replace("<", "").replace(" ", "").replace("\xa0", "")
             ),
             "tipo": hit[4],
             "precio": int(hit[5]),


### PR DESCRIPTION
Hello, here is a quick fix to solve the following error when buying resources :

<img width="1078" height="231" alt="image" src="https://github.com/user-attachments/assets/f5d51282-acc9-4fee-9041-66cfcf7d158a" />

For reference, \xa0 represents a non-breaking space.