### PR TITLE
Use parse_qs for POST form parsing

### DIFF
--- a/ikabot/function/webServer.py
+++ b/ikabot/function/webServer.py
@@ -183,7 +183,7 @@ def webServer(session, event, stdin_fd, predetermined_input, port=None):
                 if data:
                     parsed = parse_qs(data, keep_blank_values=True)
                     for k, v_list in parsed.items():
-                        new_data[k] = v_list[0] if v_list else ''
+                        new_data[k] = v_list[-1] if v_list else ''
             except Exception:
                 pass
             for arg in request.args:


### PR DESCRIPTION
Replace manual splitting and unquote-based parsing with urllib.parse.parse_qs.
Fix for #360 