### PR TITLE
fix: new action to extend building

### DIFF
--- a/ikabot/function/constructionList.py
+++ b/ikabot/function/constructionList.py
@@ -122,7 +122,7 @@ def expandBuilding(session, cityId, building, waitForResources):
             sendToBot(session, msg)
             return
 
-        url = "action=CityScreen&function=upgradeBuilding&actionRequest={}&cityId={}&position={:d}&level={}&activeTab=tabSendTransporter&backgroundView=city&currentCityId={}&templateView={}&ajax=1".format(
+        url = "action=UpgradeExistingBuilding&actionRequest={}&cityId={}&position={:d}&level={}&activeTab=tabSendTransporter&backgroundView=city&currentCityId={}&templateView={}&ajax=1".format(
             actionRequest,
             cityId,
             position,


### PR DESCRIPTION
Hello,

On my setup I had to change the action of the URL used to extend buildings in order to make it work. Seems like it arose from the upgrade to v17.0.0. Feel free to close the merge request in case I'm the only one having the error.

Thanks