### PR TITLE
fix: modifyProduction skips every other city due to island-level rate limiting

### DIFF
--- a/ikabot/function/modifyProduction.py
+++ b/ikabot/function/modifyProduction.py
@@ -3,6 +3,7 @@
 
 from ikabot.config import *
 from ikabot.helpers.pedirInfo import *
+from ikabot.helpers.varios import wait
 
 # import json
 # import re
@@ -118,7 +119,9 @@ def modifyProduction(session, event, stdin_fd, predetermined_input):
                     
                     selected_good_name = resource_name if resource_type == "resource" else tradegood_name
                     print(f"{finalWorkers} workers set for {selected_good_name} in {city['name']}.")
-                
+
+                wait(3)
+
         print("\nAll productions have been set!")
         enter()
         event.set()

--- a/ikabot/function/modifyProduction.py
+++ b/ikabot/function/modifyProduction.py
@@ -120,7 +120,7 @@ def modifyProduction(session, event, stdin_fd, predetermined_input):
                     selected_good_name = resource_name if resource_type == "resource" else tradegood_name
                     print(f"{finalWorkers} workers set for {selected_good_name} in {city['name']}.")
 
-                wait(3)
+                wait(3, 4)
 
         print("\nAll productions have been set!")
         enter()


### PR DESCRIPTION
  ## Problem

  When running the Set Production feature (menu option 23) with multiple
  cities on the same island, approximately half the cities were silently
  skipped — the code reported "X workers set for Y in Z" for all cities,
  and the server returned a successful `updateGlobalData` response for
  every request, but the game did not actually apply the worker changes
  for every other city.

  Debugging revealed a perfect alternating pattern: cities at odd
  positions in the processing order were updated correctly, while cities
  at even positions retained their previous worker allocation unchanged.

  All cities in the test case were on the same island. The root cause is
  an island-level rate limit on the game server: when `workerPlan`
  requests arrive too quickly in succession for the same island, the
  server silently accepts them (HTTP 200, valid JSON response) but does
  not apply the change to the game state.

  ## Original code

  The original loop processed all cities back-to-back with no delay
  between them, causing approximately one request every 2 seconds:

  ```python
  for city in island_data['cities']:
      # change city context, fetch slider, set workers
      session.post(params={..., "function": "workerPlan", ...})
      print(f"{finalWorkers} workers set for ...")
```
 ## Fix

  Added a randomised wait of 3–7 seconds between each city after
  processing all its resource types. This ensures the server has time to
  process each workerPlan request before the next one arrives, while
  the random offset makes the behaviour less predictable and more
  human-like.
```python
  wait(3, 4)  # waits 3 + random(0..4) seconds
```
   ## Tested

  Verified on a 13-city account (all on the same island). Before the fix,
  6 out of 13 cities were consistently skipped. After the fix, all 13
  cities were updated correctly.