### PR TITLE
fix: retry building upgrade when session context is contaminated by concurrent background tasks

### DIFF
--- a/ikabot/function/constructionList.py
+++ b/ikabot/function/constructionList.py
@@ -130,17 +130,28 @@ def expandBuilding(session, cityId, building, waitForResources):
             cityId,
             building["building"],
         )
-        resp = session.post(url)
-        html = session.get(city_url + cityId)
-        city = getCity(html)
-        building = city["position"][position]
-        if building["isBusy"] is False:
-            msg = "{}: The building {} was not extended".format(
-                city["cityName"], building["name"]
-            )
-            sendToBot(session, msg)
-            sendToBot(session, resp)
-            return
+        max_retries = 3
+        for attempt in range(1, max_retries + 1):
+            resp = session.post(url)
+            html = session.get(city_url + cityId)
+            city = getCity(html)
+            building = city["position"][position]
+            if building["isBusy"] is True:
+                break
+            if attempt < max_retries:
+                retry_wait = random.randint(10, 20)
+                msg = "{}: The building {} was not extended (attempt {}/{}). Retrying in {:d} seconds.".format(
+                    city["cityName"], building["name"], attempt, max_retries, retry_wait
+                )
+                sendToBot(session, msg)
+                time.sleep(retry_wait)
+            else:
+                msg = "{}: The building {} was not extended after {} attempts. Giving up.".format(
+                    city["cityName"], building["name"], max_retries
+                )
+                sendToBot(session, msg)
+                sendToBot(session, resp)
+                return
 
         msg = "{}: The building {} is being extended to level {:d}.".format(
             city["cityName"], building["name"], building["level"] + 1


### PR DESCRIPTION
  ## Problem

  When running `constructionList` alongside active background tasks (e.g. `activateShrine`, `loginDaily`, `autoPirate`, `distributeResources`), the building upgrade would silently fail with the Telegram
  notification:

  > CityName: The building X was not extended

  followed by a raw server response containing:
  ```json
  [["custom",["reload",{"link":"?view=city&cityId=x","isDevHost":0}]],
   ["updateBacklink",{"link":"index.php?view=militaryAdvisor&backlink=1","title":"..."}],
   ...]
```
  ## Root Cause


  Ikabot background tasks share the same HTTP session. When a background task makes a request at the same moment as the UpgradeExistingBuilding POST, the server-side session context gets contaminated and
  the upgrade is silently rejected. Since the code did not validate the POST response before checking isBusy, it gave up immediately on the first failure.

  ## Fix

  Added a retry loop (up to 3 attempts) around the UpgradeExistingBuilding POST in expandBuilding(). Each failed attempt notifies via Telegram with the attempt number and a random delay of 10–20 seconds
  before retrying. The random delay gives any in-flight concurrent request time to complete. If all 3 attempts fail, a final Telegram notification is sent with the raw server response for debugging.

 ## Behaviour before fix

  Attempt 1 fails → "The building X was not extended" + raw response → stops

  Behaviour after fix

  Attempt 1 fails → "The building X was not extended (attempt 1/3). Retrying in 14 seconds."
  Attempt 2 fails → "The building X was not extended (attempt 2/3). Retrying in 17 seconds."
  Attempt 3 fails → "The building X was not extended after 3 attempts. Giving up." + raw response
  or
  Attempt 1 fails → "The building X was not extended (attempt 1/3). Retrying in 14 seconds."
  Attempt 2 succeeds → continues normally

  ## Related Issues

  Closes #382