### PR TITLE
Switch wait() jitter from uniform to log-normal

### DIFF
--- a/ikabot/helpers/varios.py
+++ b/ikabot/helpers/varios.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python3
 # -*- coding: utf-8 -*-
 
+import math
 import random
 import re
 import time
@@ -57,7 +58,7 @@ def daysHoursMinutes(totalSeconds):
 
 
 def wait(seconds, maxrandom=0):
-    """This function will wait the provided number of seconds plus a random number of seconds between 0 and maxrandom
+    """This function will wait the provided number of seconds plus a random number of seconds drawn from a log-normal distribution capped at maxrandom
     Parameters
     -----------
     seconds : int
@@ -67,15 +68,12 @@ def wait(seconds, maxrandom=0):
     """
     if seconds <= 0:
         return
-    randomTime = random.randint(0, maxrandom)
-    ratio = (1 + 5**0.5) / 2 - 1  # 0.6180339887498949
-    comienzo = time.time()
-    fin = comienzo + seconds
-    restantes = seconds
-    while restantes > 0:
-        time.sleep(restantes * ratio)
-        restantes = fin - time.time()
-    time.sleep(randomTime)
+    if maxrandom > 0:
+        mu = math.log(maxrandom / 2)
+        jitter = min(random.lognormvariate(mu, 0.5), maxrandom)
+    else:
+        jitter = 0
+    time.sleep(seconds + jitter)
 
 
 def getCurrentCityId(session):


### PR DESCRIPTION
I was building my own auto-pirate as a browser extension and came
across your `wait()` helper while comparing approaches. The
golden-ratio loop collapses to a plain `time.sleep` (the constant
doesn't matter), and the only real jitter is uniform.

This PR replaces the body with a log-normal draw — same signature,
same upper bound on extra delay, same median wait, just closer to
how human reaction times actually distribute.