### PR TITLE
Suppress onnxruntime GPU discovery stderr spam

### DIFF
--- a/ikabot/helpers/piratesDecaptcha.py
+++ b/ikabot/helpers/piratesDecaptcha.py
@@ -1,17 +1,30 @@
 import os
+import sys
+
+class SuppressStderr:
+    def __enter__(self):
+        self._devnull = os.open(os.devnull, os.O_WRONLY)
+        self._old_stderr = os.dup(2)
+        os.dup2(self._devnull, 2)
+    def __exit__(self, *args):
+        os.dup2(self._old_stderr, 2)
+        os.close(self._old_stderr)
+        os.close(self._devnull)
+
 import struct
 import zlib
 import io
 import requests
 
-try:
-    from onnxruntime_inference_collection import InferenceSession # Ignore, this only works if you have the onnxruntime_pybind11_state.pyd file for win
-except:                                                           # or onnxruntime_pybind11_state.cpython-310-x86_64-linux-gnu.so for linux
+with SuppressStderr():
     try:
-        from onnxruntime import InferenceSession
+        from onnxruntime_inference_collection import InferenceSession
     except:
-        print('ERROR: COULD NOT FIND ONNXRUNTIME INFERENCE SESSION!')
-        raise
+        try:
+            from onnxruntime import InferenceSession
+        except:
+            print('ERROR: COULD NOT FIND ONNXRUNTIME INFERENCE SESSION!')
+            raise
 
 if os.name == 'nt':
     _temp = os.getenv('temp') or os.getenv('TMP') or os.getenv('TEMP') or '.'
@@ -21,7 +34,6 @@ else:
 
 _url = 'https://github.com/Ikabot-Collective/IkabotAPI/raw/4ebe57a3f1c11acb357a4bf4b6f7f92e1da287ce/apps/decaptcha/pirates_captcha/ikaptcha.onnx'
 session = None
-
 
 def _load_model():
     global session

--- a/ikabot/helpers/piratesDecaptcha.py
+++ b/ikabot/helpers/piratesDecaptcha.py
@@ -18,8 +18,8 @@ import requests
 
 with SuppressStderr():
     try:
-        from onnxruntime_inference_collection import InferenceSession
-    except:
+        from onnxruntime_inference_collection import InferenceSession # NOTE: This only works if you have the onnxruntime_pybind11_state.pyd file for win
+    except:                                                           # or onnxruntime_pybind11_state.cpython-310-x86_64-linux-gnu.so for linux
         try:
             from onnxruntime import InferenceSession
         except:


### PR DESCRIPTION
When starting Ikabot on systems without a GPU, a C library error message is displayed due to the import of this module. This change adds a workaround to suppress those import-related errors and avoid unnecessary log noise.
<img width="1873" height="60" alt="image" src="https://github.com/user-attachments/assets/c406bfc7-469b-4d6b-accb-ed42c8e430db" />

