### PR TITLE
Fix local network IP resolution across Windows and Linux

### DIFF
--- a/ikabot/function/webServer.py
+++ b/ikabot/function/webServer.py
@@ -322,7 +322,10 @@ def webServer(session, event, stdin_fd, predetermined_input, port=None):
         # try to get local network ip if possible
         local_network_ip = None
         try:
-            local_network_ip = socket.gethostbyname(socket.gethostname())
+            with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+                # We are pointing to a generic local router IP address (it doesn't need to exist)
+                s.connect(("192.168.1.1", 80))
+                local_network_ip = s.getsockname()[0]
         except:
             pass
         print(

--- a/ikabot/function/webServer.py
+++ b/ikabot/function/webServer.py
@@ -42,6 +42,31 @@ else:
     web_cache_file = "/tmp/ikabot.webcache"
 
 
+def get_local_network_ip():
+    def is_usable_ip(ip):
+        return ip and not ip.startswith(("0.", "127.", "169.254."))
+
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+            # No packet is sent; connect only asks the OS which local address
+            # would be used for this route.
+            s.connect(("1.1.1.1", 80))
+            ip = s.getsockname()[0]
+            if is_usable_ip(ip):
+                return ip
+    except OSError:
+        pass
+
+    try:
+        ip = socket.gethostbyname(socket.gethostname())
+        if is_usable_ip(ip):
+            return ip
+    except OSError:
+        pass
+
+    return None
+
+
 def webServer(session, event, stdin_fd, predetermined_input, port=None):
     """
     Parameters
@@ -320,14 +345,7 @@ def webServer(session, event, stdin_fd, predetermined_input, port=None):
                 port = str(int(port) + 1)
 
         # try to get local network ip if possible
-        local_network_ip = None
-        try:
-            with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
-                # We are pointing to a generic local router IP address (it doesn't need to exist)
-                s.connect(("192.168.1.1", 80))
-                local_network_ip = s.getsockname()[0]
-        except:
-            pass
+        local_network_ip = get_local_network_ip()
         print(
             f"""Ikabot web server is about to be run on {bcolors.BLUE}http://127.0.0.1:{port}{bcolors.ENDC} {'and ' + bcolors.BLUE + 'http://' + str(local_network_ip) + ':' + port + bcolors.ENDC if local_network_ip else ''}"""
         )


### PR DESCRIPTION
## Description
This PR fixes an issue where `socket.gethostbyname(socket.gethostname())` was returning incorrect local IPs depending on the OS (an APIPA `169.254.x.x` address on Windows due to virtual adapters, and the loopback `127.0.1.1` address on Linux).

## Changes
- Replaced the hostname-based IP lookup with a dummy UDP socket connection to `192.168.1.1`.
- This forces the OS routing table to correctly identify and return the primary local network interface IP, regardless of the platform.

<img width="1582" height="237" alt="image" src="https://github.com/user-attachments/assets/e82dcccf-ede2-4541-87d5-45d4ea3e5b91" />
