### PR TITLE
Fix menu options

### DIFF
--- a/ikabot/command_line.py
+++ b/ikabot/command_line.py
@@ -310,6 +310,12 @@ def menu(session, checkUpdate=True):
         if selected > 0:
             selected += 2100
 
+    if selected not in menu_actions and selected != 0:
+        print("Invalid option")
+        enter()
+        menu(session, checkUpdate=False)
+        return
+
     if selected != 0:
         try:
             event = multiprocessing.Event()  # creates a new event

--- a/ikabot/helpers/pedirInfo.py
+++ b/ikabot/helpers/pedirInfo.py
@@ -65,7 +65,7 @@ def read(
         pass
     
     def _invalid():
-        print("\033[1A\033[K", end="")  # remove line
+        print("\033[1A\033[KInvalid option")
         return read(min=min, max=max, digit=digit, msg=msg, values=values, empty=empty, additionalValues=additionalValues, default=default, _retries=_retries+1, _max_retries=_max_retries)
     
     try:


### PR DESCRIPTION
Summary
Problem: Entering an invalid menu option in command_line.py either crashes the program (options 25-41 that pass read() validation but aren't in menu_actions → KeyError) or silently re-prompts without feedback (options >41, silently rejected by read()'s _invalid() with just an ANSI clear).

Changes:
1. helpers/pedirInfo.py — _invalid() now prints "Invalid option" before re-prompting, instead of silently clearing the line.
2. command_line.py — Added a guard (selected not in menu_actions and selected != 0) before the menu_actions[selected] lookup to catch options that pass read() validation but have no matching action, printing "Invalid option" and returning to the menu instead of crashing with KeyError.