### PR TITLE
feat: replace hardcoded locale, gf_lang, and timezone with environment

### DIFF
--- a/ikabot/config.py
+++ b/ikabot/config.py
@@ -17,6 +17,17 @@ update_msg = ""
 
 isWindows = os.name == "nt"
 
+# Regional Settings (Environment Variables)
+# If login fails with HTTP 409 (Gameforge rejecting the blackbox token / credentials),
+# these environment variables should be set to match your machine's actual region and timezone:
+# - IKABOT_LOCALE: Client's locale tag (e.g., "es-AR", "es-ES", "de-DE", "en-US", fallback: "en-GB")
+# - IKABOT_GF_LANG: Gameforge lobby language (e.g., "es", "de", "en", fallback: "en")
+# - IKABOT_TIMEZONE_ID: Client's timezone ID (e.g., "America/Argentina/Buenos_Aires", "Europe/Madrid", fallback: "Europe/London")
+
+IKABOT_LOCALE = "en-GB"
+IKABOT_GF_LANG = "en"
+IKABOT_TIMEZONE_ID = "Europe/London"
+
 
 LOGS_DIRECTORY_FILE = os.getenv("temp") + "/ikabot.log" if isWindows else "/tmp/ikabot.log"
 DEFAULT_LOG_LEVEL = 30 # Warning

--- a/ikabot/helpers/apiComm.py
+++ b/ikabot/helpers/apiComm.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python3
 # -*- coding: utf-8 -*-
 
+import os
 import traceback
 
 from requests import get, post
@@ -24,8 +25,8 @@ def getNewBlackBoxToken(session):
     address = getAddress(publicAPIServerDomain) + "/v1/token"
     params = {
         "user_agent": session.user_agent,
-        "locale": getattr(session, "locale", "en-GB"),
-        "timezone_id": getattr(session, "timezone_id", "Europe/London"),
+        "locale": getattr(session, "locale", None) or os.environ.get("IKABOT_LOCALE") or getattr(config, "IKABOT_LOCALE", "en-GB") or "en-GB",
+        "timezone_id": getattr(session, "timezone_id", None) or os.environ.get("IKABOT_TIMEZONE_ID") or getattr(config, "IKABOT_TIMEZONE_ID", "Europe/London") or "Europe/London",
     }
     response = get(
         address, params=params, verify=do_ssl_verify, timeout=900

--- a/ikabot/web/session.py
+++ b/ikabot/web/session.py
@@ -34,10 +34,10 @@ class Session:
         self.padre = True
         self.logged = False
         self.blackbox = None
-        self.locale = "en-GB"
-        self.gf_lang = "en"
-        self.accept_language = "en-GB,en;q=0.9"
-        self.timezone_id = "Europe/London"
+        self.locale = os.environ.get("IKABOT_LOCALE") or getattr(config, "IKABOT_LOCALE", "en-GB") or "en-GB"
+        self.gf_lang = os.environ.get("IKABOT_GF_LANG") or getattr(config, "IKABOT_GF_LANG", "en") or "en"
+        self.accept_language = f"{self.locale},{self.gf_lang};q=0.9"
+        self.timezone_id = os.environ.get("IKABOT_TIMEZONE_ID") or getattr(config, "IKABOT_TIMEZONE_ID", "Europe/London") or "Europe/London"
         self.logger = getLogger(__name__)
         self.requestHistory = deque(maxlen=5)  # keep last 5 requests in history
         # disable ssl verification warning
@@ -693,7 +693,7 @@ class Session:
             "Accept": "application/json",
             "Accept-Language": self.accept_language,
             "Accept-Encoding": "gzip, deflate",
-            "Referer": "https://lobby.ikariam.gameforge.com/es_AR/hub",
+            "Referer": "https://lobby.ikariam.gameforge.com/{}/hub".format(self.locale.replace('-', '_')),
             "Authorization": "Bearer {}".format(self.s.cookies["gf-token-production"]),
             "DNT": "1",
             "Connection": "close",
@@ -710,7 +710,7 @@ class Session:
             "Accept": "application/json",
             "Accept-Language": self.accept_language,
             "Accept-Encoding": "gzip, deflate",
-            "Referer": "https://lobby.ikariam.gameforge.com/es_AR/hub",
+            "Referer": "https://lobby.ikariam.gameforge.com/{}/hub".format(self.locale.replace('-', '_')),
             "Authorization": "Bearer {}".format(self.s.cookies["gf-token-production"]),
             "DNT": "1",
             "Connection": "close",
@@ -851,7 +851,7 @@ class Session:
                 "authorization": "Bearer " + self.s.cookies["gf-token-production"],
                 "content-type": "application/json",
                 "origin": "https://lobby.ikariam.gameforge.com",
-                "referer": "https://lobby.ikariam.gameforge.com/en_GB/accounts",
+                "referer": "https://lobby.ikariam.gameforge.com/{}/accounts".format(self.locale.replace('-', '_')),
                 "user-agent": self.user_agent,
             }
             self.s.headers.clear()


### PR DESCRIPTION
1. Centralized Constants & Documentation (ikabot/config.py)
- Declared default configuration constants:
IKABOT_LOCALE = "en-GB"
IKABOT_GF_LANG = "en"
IKABOT_TIMEZONE_ID = "Europe/London"
- Added a detailed English commentary block in the config module explaining how users experiencing HTTP 409 login errors can easily adapt Ikabot to their machine's local timezone and regional configurations using environment variables.
2. Robust Multi-Tier Inline Fallbacks (ikabot/web/session.py & helpers/apiComm.py)
- Designed a bulletproof resolution flow for session initialization and API token calls using dynamic lookups (getattr() and standard boolean evaluation):
1. Primary: Fetch from environment variables (IKABOT_LOCALE, IKABOT_GF_LANG, IKABOT_TIMEZONE_ID).
2. Secondary: Safely fallback to constants configured in ikabot/config.py.
3. Tertiary (Inline Salvage): Use default hardcoded literals (en-GB, en, Europe/London) as a last resort, shielding the application from runtime NameError exceptions even if configuration values are completely deleted or set to empty strings.
3. Fully Dynamic Request URLs & Referers (ikabot/web/session.py)
- Lobby requests and Referer headers dynamically format hyphenated tags into underscores (converting es-AR or en-GB to es_AR or en_GB) to perfectly align with Gameforge API routing standards:
"Referer": "https://lobby.ikariam.gameforge.com/{}/hub".format(self.locale.replace('-', '_'))