### PR TITLE
Add regional context support for blackbox tokens

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,6 @@
 CUSTOM_API_ADDRESS=http://127.0.0.1:5000
+
+# Optional regional settings used for Gameforge login and blackbox token generation.
+IKABOT_LOCALE=en-GB
+IKABOT_GF_LANG=en
+IKABOT_TIMEZONE_ID=Europe/London

--- a/ikabot/config.py
+++ b/ikabot/config.py
@@ -17,16 +17,28 @@ update_msg = ""
 
 isWindows = os.name == "nt"
 
-# Regional Settings (Environment Variables)
-# If login fails with HTTP 409 (Gameforge rejecting the blackbox token / credentials),
-# these environment variables should be set to match your machine's actual region and timezone:
-# - IKABOT_LOCALE: Client's locale tag (e.g., "es-AR", "es-ES", "de-DE", "en-US", fallback: "en-GB")
-# - IKABOT_GF_LANG: Gameforge lobby language (e.g., "es", "de", "en", fallback: "en")
-# - IKABOT_TIMEZONE_ID: Client's timezone ID (e.g., "America/Argentina/Buenos_Aires", "Europe/Madrid", fallback: "Europe/London")
+# Regional Settings
+# These environment variables can be set to match the user's browser region and
+# timezone when Gameforge rejects generated blackbox tokens.
+IKABOT_LOCALE = (os.getenv("IKABOT_LOCALE") or "en-GB").strip() or "en-GB"
+IKABOT_GF_LANG = (
+    os.getenv("IKABOT_GF_LANG") or IKABOT_LOCALE.split("-")[0]
+).strip() or "en"
+IKABOT_TIMEZONE_ID = (
+    os.getenv("IKABOT_TIMEZONE_ID") or "Europe/London"
+).strip() or "Europe/London"
 
-IKABOT_LOCALE = "en-GB"
-IKABOT_GF_LANG = "en"
-IKABOT_TIMEZONE_ID = "Europe/London"
+
+def build_accept_language(locale_value=IKABOT_LOCALE, gf_lang=IKABOT_GF_LANG):
+    locale_value = (locale_value or IKABOT_LOCALE).strip() or IKABOT_LOCALE
+    gf_lang = (gf_lang or locale_value.split("-")[0]).strip() or "en"
+
+    parts = [locale_value]
+    if gf_lang != locale_value:
+        parts.append(f"{gf_lang};q=0.9")
+    if gf_lang != "en" and locale_value != "en":
+        parts.append("en;q=0.8")
+    return ",".join(parts)
 
 
 LOGS_DIRECTORY_FILE = os.getenv("temp") + "/ikabot.log" if isWindows else "/tmp/ikabot.log"

--- a/ikabot/config.py
+++ b/ikabot/config.py
@@ -17,6 +17,17 @@ update_msg = ""
 
 isWindows = os.name == "nt"
 
+# Regional Settings (Environment Variables)
+# If login fails with HTTP 409 (Gameforge rejecting the blackbox token / credentials),
+# these environment variables should be set to match your machine's actual region and timezone:
+# - IKABOT_LOCALE: Client's locale tag (e.g., "es-AR", "es-ES", "de-DE", "en-US", fallback: "en-GB")
+# - IKABOT_GF_LANG: Gameforge lobby language (e.g., "es", "de", "en", fallback: "en")
+# - IKABOT_TIMEZONE_ID: Client's timezone ID (e.g., "America/Argentina/Buenos_Aires", "Europe/Madrid", fallback: "Europe/London")
+
+IKABOT_LOCALE = "en-GB"
+IKABOT_GF_LANG = "en"
+IKABOT_TIMEZONE_ID = "Europe/London"
+
 
 LOGS_DIRECTORY_FILE = os.getenv("temp") + "/ikabot.log" if isWindows else "/tmp/ikabot.log"
 DEFAULT_LOG_LEVEL = 30 # Warning

--- a/ikabot/helpers/apiComm.py
+++ b/ikabot/helpers/apiComm.py
@@ -1,7 +1,6 @@
 #! /usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-import os
 import traceback
 
 from requests import get, post
@@ -25,8 +24,8 @@ def getNewBlackBoxToken(session):
     address = getAddress(publicAPIServerDomain) + "/v1/token"
     params = {
         "user_agent": session.user_agent,
-        "locale": getattr(session, "locale", None) or os.environ.get("IKABOT_LOCALE") or getattr(config, "IKABOT_LOCALE", "en-GB") or "en-GB",
-        "timezone_id": getattr(session, "timezone_id", None) or os.environ.get("IKABOT_TIMEZONE_ID") or getattr(config, "IKABOT_TIMEZONE_ID", "Europe/London") or "Europe/London",
+        "locale": session.locale,
+        "timezone_id": session.timezone_id,
     }
     response = get(
         address, params=params, verify=do_ssl_verify, timeout=900

--- a/ikabot/helpers/apiComm.py
+++ b/ikabot/helpers/apiComm.py
@@ -1,6 +1,7 @@
 #! /usr/bin/env python3
 # -*- coding: utf-8 -*-
 
+import os
 import traceback
 
 from requests import get, post
@@ -24,8 +25,8 @@ def getNewBlackBoxToken(session):
     address = getAddress(publicAPIServerDomain) + "/v1/token"
     params = {
         "user_agent": session.user_agent,
-        "locale": getattr(session, "locale", "en-GB"),
-        "timezone_id": getattr(session, "timezone_id", "Europe/London"),
+        "locale": getattr(session, "locale", None) or os.environ.get("IKABOT_LOCALE") or getattr(config, "IKABOT_LOCALE", "en-GB") or "en-GB",
+        "timezone_id": getattr(session, "timezone_id", None) or os.environ.get("IKABOT_TIMEZONE_ID") or getattr(config, "IKABOT_TIMEZONE_ID", "Europe/London") or "Europe/London",
     }
     response = get(
         address, params=params, verify=do_ssl_verify, timeout=900

--- a/ikabot/web/session.py
+++ b/ikabot/web/session.py
@@ -34,10 +34,10 @@ class Session:
         self.padre = True
         self.logged = False
         self.blackbox = None
-        self.locale = os.environ.get("IKABOT_LOCALE") or getattr(config, "IKABOT_LOCALE", "en-GB") or "en-GB"
-        self.gf_lang = os.environ.get("IKABOT_GF_LANG") or getattr(config, "IKABOT_GF_LANG", "en") or "en"
-        self.accept_language = f"{self.locale},{self.gf_lang};q=0.9"
-        self.timezone_id = os.environ.get("IKABOT_TIMEZONE_ID") or getattr(config, "IKABOT_TIMEZONE_ID", "Europe/London") or "Europe/London"
+        self.locale = config.IKABOT_LOCALE
+        self.gf_lang = config.IKABOT_GF_LANG
+        self.accept_language = config.build_accept_language(self.locale, self.gf_lang)
+        self.timezone_id = config.IKABOT_TIMEZONE_ID
         self.logger = getLogger(__name__)
         self.requestHistory = deque(maxlen=5)  # keep last 5 requests in history
         # disable ssl verification warning
@@ -191,6 +191,19 @@ class Session:
             user_agent = payload.get("user_agent") or payload.get("userAgent")
             if isinstance(user_agent, str) and user_agent:
                 self.user_agent = user_agent
+
+            locale = payload.get("locale")
+            if not os.environ.get("IKABOT_LOCALE") and isinstance(locale, str) and locale.strip():
+                self.locale = locale.strip()
+                if not os.environ.get("IKABOT_GF_LANG"):
+                    self.gf_lang = self.locale.split("-")[0]
+                self.accept_language = config.build_accept_language(
+                    self.locale, self.gf_lang
+                )
+
+            timezone_id = payload.get("timezone_id") or payload.get("timezoneId")
+            if not os.environ.get("IKABOT_TIMEZONE_ID") and isinstance(timezone_id, str) and timezone_id.strip():
+                self.timezone_id = timezone_id.strip()
 
         except json.JSONDecodeError:
             pass

--- a/ikabot/web/session.py
+++ b/ikabot/web/session.py
@@ -34,10 +34,10 @@ class Session:
         self.padre = True
         self.logged = False
         self.blackbox = None
-        self.locale = "en-GB"
-        self.gf_lang = "en"
-        self.accept_language = "en-GB,en;q=0.9"
-        self.timezone_id = "Europe/London"
+        self.locale = os.environ.get("IKABOT_LOCALE") or getattr(config, "IKABOT_LOCALE", "en-GB") or "en-GB"
+        self.gf_lang = os.environ.get("IKABOT_GF_LANG") or getattr(config, "IKABOT_GF_LANG", "en") or "en"
+        self.accept_language = f"{self.locale},{self.gf_lang};q=0.9"
+        self.timezone_id = os.environ.get("IKABOT_TIMEZONE_ID") or getattr(config, "IKABOT_TIMEZONE_ID", "Europe/London") or "Europe/London"
         self.logger = getLogger(__name__)
         self.requestHistory = deque(maxlen=5)  # keep last 5 requests in history
         # disable ssl verification warning
@@ -693,7 +693,7 @@ class Session:
             "Accept": "application/json",
             "Accept-Language": self.accept_language,
             "Accept-Encoding": "gzip, deflate",
-            "Referer": "https://lobby.ikariam.gameforge.com/es_AR/hub",
+            "Referer": "https://lobby.ikariam.gameforge.com/{}/hub".format(self.locale.replace('-', '_')),
             "Authorization": "Bearer {}".format(self.s.cookies["gf-token-production"]),
             "DNT": "1",
             "Connection": "close",
@@ -710,7 +710,7 @@ class Session:
             "Accept": "application/json",
             "Accept-Language": self.accept_language,
             "Accept-Encoding": "gzip, deflate",
-            "Referer": "https://lobby.ikariam.gameforge.com/es_AR/hub",
+            "Referer": "https://lobby.ikariam.gameforge.com/{}/hub".format(self.locale.replace('-', '_')),
             "Authorization": "Bearer {}".format(self.s.cookies["gf-token-production"]),
             "DNT": "1",
             "Connection": "close",
@@ -851,7 +851,7 @@ class Session:
                 "authorization": "Bearer " + self.s.cookies["gf-token-production"],
                 "content-type": "application/json",
                 "origin": "https://lobby.ikariam.gameforge.com",
-                "referer": "https://lobby.ikariam.gameforge.com/en_GB/accounts",
+                "referer": "https://lobby.ikariam.gameforge.com/{}/accounts".format(self.locale.replace('-', '_')),
                 "user-agent": self.user_agent,
             }
             self.s.headers.clear()


### PR DESCRIPTION
Adds configurable regional context support for Gameforge login and blackbox token generation.

Changes:
- Adds `IKABOT_LOCALE`, `IKABOT_GF_LANG`, and `IKABOT_TIMEZONE_ID`
- Sends locale and timezone context when requesting API-generated blackbox tokens
- Aligns Gameforge login payloads and headers with the configured locale/lang
- Derives `gf_lang` and `Accept-Language` when possible
- Keeps compatibility with older APIs by retrying token requests without the new params
- Extends manual blackbox JSON payload handling with browser context fallback
- Documents the new environment variables in `.env.example`